### PR TITLE
Versioner should be inclusive of LTS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 
 group 'com.bnc.gradle'
 
-sourceCompatibility = JavaVersion.VERSION_13
-targetCompatibility = JavaVersion.VERSION_13
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Though many Java projects are still jdk8 & jdk9. 

Should we support a wider range of projects or is 11 satisfactory?